### PR TITLE
Add ELOP tolerance profile

### DIFF
--- a/rules_profiles.py
+++ b/rules_profiles.py
@@ -100,10 +100,31 @@ IND_STD = (
     TolRule(1.00e-03, 1.00e+00,  5.0, 25.0),
 )
 
+ELOP_RES = (
+    TolRule(100.0001, 1.00e+09, 5.0, 5.0),
+    TolRule(33.0,    100.0,    10.0, 10.0),
+    TolRule(0.0,      32.9999, 20.0, 20.0),
+)
+
+ELOP_CAP = (
+    TolRule(1.00e-07, 1.00e+03, 5.0, 5.0),
+    TolRule(3.00e-11, 9.99e-08,10.0,10.0),
+    TolRule(0.0,      2.999e-11,20.0,20.0),
+)
+
+ELOP_IND = (
+    TolRule(1.00e-01, 1.00e+09, 5.0, 5.0),
+    TolRule(1.00e-03, 9.99e-02,10.0,10.0),
+    TolRule(0.0,      9.99e-04,15.0,15.0),
+)
+
 PROFILES = {
     'MABAT (Resistors)': ('Ω', parse_res_value_to_ohms, tuple(MABAT_A), tuple(MABAT_B), 0.1),
     'Capacitor (F)':     ('F', parse_cap_value_to_farads, tuple(CAP_STD), None, None),
     'Inductor (H)':      ('H', parse_ind_value_to_henries, tuple(IND_STD), None, None),
+    'ELOP (Resistors)':  ('Ω', parse_res_value_to_ohms, tuple(ELOP_RES), None, None),
+    'ELOP (Capacitors)': ('F', parse_cap_value_to_farads, tuple(ELOP_CAP), None, None),
+    'ELOP (Inductors)':  ('H', parse_ind_value_to_henries, tuple(ELOP_IND), None, None),
 }
 
 def _select_rule(x: float, table: Tuple[TolRule, ...]) -> TolRule:

--- a/tests/test_elop_profile.py
+++ b/tests/test_elop_profile.py
@@ -1,0 +1,24 @@
+import pathlib, sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from rules_profiles import compute_new_tolerance_pct
+
+
+def test_elop_resistor_rules():
+    assert compute_new_tolerance_pct('ELOP (Resistors)', 10, 1) == 20.0
+    assert compute_new_tolerance_pct('ELOP (Resistors)', 50, 1) == 10.0
+    assert compute_new_tolerance_pct('ELOP (Resistors)', 1000, 1) == 5.0
+
+
+def test_elop_capacitor_rules():
+    assert compute_new_tolerance_pct('ELOP (Capacitors)', '10pF', 0) == 20.0
+    assert compute_new_tolerance_pct('ELOP (Capacitors)', '50pF', 0) == 10.0
+    assert compute_new_tolerance_pct('ELOP (Capacitors)', '1uF', 0) == 5.0
+
+
+def test_elop_inductor_rules():
+    assert compute_new_tolerance_pct('ELOP (Inductors)', '500uH', 0) == 15.0
+    assert compute_new_tolerance_pct('ELOP (Inductors)', '10mH', 0) == 10.0
+    assert compute_new_tolerance_pct('ELOP (Inductors)', '1H', 0) == 5.0
+


### PR DESCRIPTION
## Summary
- add ELOP profile with fixed tolerance bands for resistors, capacitors, and inductors
- allow GUI selection of ELOP profile and map components accordingly
- ensure module imports without PyQt installed and add unit tests for ELOP rules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a46b17d274832cbce6998b2275f40c