### PR TITLE
Add profile constructor GUI and launch button

### DIFF
--- a/profile_constructor_gui.py
+++ b/profile_constructor_gui.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+import sys
+
+try:
+    from PyQt6.QtWidgets import QApplication, QWidget, QVBoxLayout, QLabel
+except Exception:  # pragma: no cover - allows import without PyQt installed
+    class _Dummy:
+        def __init__(self, *a, **k):
+            pass
+
+        def __getattr__(self, name):
+            return _Dummy()
+
+        def __call__(self, *a, **k):
+            return _Dummy()
+
+    QApplication = QWidget = QVBoxLayout = QLabel = _Dummy
+
+
+class ProfileConstructorWindow(QWidget):
+    """Simple placeholder window for constructing tolerance profiles."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle('Profile Constructor')
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel('Profile constructor GUI placeholder.'))
+
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    w = ProfileConstructorWindow()
+    w.show()
+    sys.exit(app.exec())
+
+
+if __name__ == '__main__':  # pragma: no cover - manual GUI launch
+    main()

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,2 +1,3 @@
 def test_import():
     import tolerance_gui
+    import profile_constructor_gui

--- a/tolerance_gui.py
+++ b/tolerance_gui.py
@@ -156,8 +156,12 @@ class FileSelectPage(QWizardPage):
         self.threshold_note = QLabel('MABAT: auto-applies R/C/L rules; resistor threshold is fixed at 0.1%')
         self.threshold_note.setStyleSheet('color: gray;')
 
+        self.btn_profile_constructor = QPushButton('Profile Constructor…')
+        self.btn_profile_constructor.clicked.connect(self.open_profile_constructor)
+
         layout.addLayout(rule_row)
         layout.addWidget(self.threshold_note)
+        layout.addWidget(self.btn_profile_constructor)
         layout.addWidget(btn_add_xml)
         layout.addWidget(self.xml_list)
         layout.addWidget(self.use_xml_bom)
@@ -191,6 +195,15 @@ class FileSelectPage(QWizardPage):
             self.bom_path = pathlib.Path(f)
             self.bom_label.setText(str(self.bom_path))
             self.completeChanged.emit()
+
+    def open_profile_constructor(self):
+        try:
+            from profile_constructor_gui import ProfileConstructorWindow
+        except Exception as e:  # pragma: no cover - import fallback
+            QMessageBox.critical(self, 'Error', f'Profile constructor GUI not available: {e}')
+            return
+        self._constructor_win = ProfileConstructorWindow()
+        self._constructor_win.show()
 
     def initializePage(self):
         self.xml_paths = []


### PR DESCRIPTION
## Summary
- Add placeholder `ProfileConstructorWindow` with PyQt6-compatible fallbacks.
- Provide "Profile Constructor…" button in wizard to open the constructor GUI.
- Extend import tests to cover new module.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5f82df7a0832c82f30ad3d9bf17f5