### PR TITLE
Load tolerance profiles from JSON files

### DIFF
--- a/profile_constructor_gui.py
+++ b/profile_constructor_gui.py
@@ -9,6 +9,7 @@ entered ranges cover the full span without gaps.
 """
 
 import sys
+import pathlib
 
 from rules_profiles import (
     ComponentRules,
@@ -16,6 +17,7 @@ from rules_profiles import (
     check_rules_cover,
     make_tol_rule,
     save_profile_set,
+    register_profile_set,
 )
 
 try:  # pragma: no cover - the GUI is optional for tests
@@ -186,10 +188,19 @@ class ProfileConstructorWindow(QWidget):
             inductor=ComponentRules(table_a=tuple(i_rules)) if i_rules else None,
         )
 
-        path, _ = QFileDialog.getSaveFileName(self, "Save profile set", "", "JSON files (*.json)")
+        folder = pathlib.Path(__file__).resolve().parent / "profiles"
+        folder.mkdir(exist_ok=True)
+        default = folder / f"{name.strip()}.json"
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Save profile set",
+            str(default),
+            "JSON files (*.json)",
+        )
         if path:
             try:  # pragma: no cover - file IO
                 save_profile_set(prof, path)
+                register_profile_set(prof)
                 QMessageBox.information(self, "Saved", f"Profile saved to {path}")
             except Exception as e:
                 QMessageBox.critical(self, "Error", str(e))

--- a/profiles/ELOP.json
+++ b/profiles/ELOP.json
@@ -1,0 +1,72 @@
+{
+  "capacitor": {
+    "default_threshold_pct": null,
+    "table_a": [
+      {
+        "extension_allowed_pct": 5.0,
+        "max_allowed_pct": 5.0,
+        "vmax": 1000.0,
+        "vmin": 1e-07
+      },
+      {
+        "extension_allowed_pct": 10.0,
+        "max_allowed_pct": 10.0,
+        "vmax": 9.99e-08,
+        "vmin": 3e-11
+      },
+      {
+        "extension_allowed_pct": 20.0,
+        "max_allowed_pct": 20.0,
+        "vmax": 2.999e-11,
+        "vmin": 0.0
+      }
+    ]
+  },
+  "inductor": {
+    "default_threshold_pct": null,
+    "table_a": [
+      {
+        "extension_allowed_pct": 5.0,
+        "max_allowed_pct": 5.0,
+        "vmax": 1000000000.0,
+        "vmin": 0.1
+      },
+      {
+        "extension_allowed_pct": 10.0,
+        "max_allowed_pct": 10.0,
+        "vmax": 0.0999,
+        "vmin": 0.001
+      },
+      {
+        "extension_allowed_pct": 15.0,
+        "max_allowed_pct": 15.0,
+        "vmax": 0.000999,
+        "vmin": 0.0
+      }
+    ]
+  },
+  "name": "ELOP",
+  "resistor": {
+    "default_threshold_pct": null,
+    "table_a": [
+      {
+        "extension_allowed_pct": 5.0,
+        "max_allowed_pct": 5.0,
+        "vmax": 1000000000.0,
+        "vmin": 100.0001
+      },
+      {
+        "extension_allowed_pct": 10.0,
+        "max_allowed_pct": 10.0,
+        "vmax": 100.0,
+        "vmin": 33.0
+      },
+      {
+        "extension_allowed_pct": 20.0,
+        "max_allowed_pct": 20.0,
+        "vmax": 32.9999,
+        "vmin": 0.0
+      }
+    ]
+  }
+}

--- a/profiles/MABAT.json
+++ b/profiles/MABAT.json
@@ -1,0 +1,128 @@
+{
+  "capacitor": {
+    "default_threshold_pct": null,
+    "table_a": [
+      {
+        "extension_allowed_pct": 20.0,
+        "max_allowed_pct": 30.0,
+        "vmax": 4.99e-10,
+        "vmin": 1e-20
+      },
+      {
+        "extension_allowed_pct": 15.0,
+        "max_allowed_pct": 25.0,
+        "vmax": 9.99e-09,
+        "vmin": 5e-10
+      },
+      {
+        "extension_allowed_pct": 5.0,
+        "max_allowed_pct": 15.0,
+        "vmax": 9.99e-07,
+        "vmin": 1e-08
+      },
+      {
+        "extension_allowed_pct": 3.0,
+        "max_allowed_pct": 13.0,
+        "vmax": 1.0,
+        "vmin": 1e-06
+      }
+    ]
+  },
+  "inductor": {
+    "default_threshold_pct": null,
+    "table_a": [
+      {
+        "extension_allowed_pct": 15.0,
+        "max_allowed_pct": 35.0,
+        "vmax": 0.001,
+        "vmin": 1e-05
+      },
+      {
+        "extension_allowed_pct": 5.0,
+        "max_allowed_pct": 25.0,
+        "vmax": 1.0,
+        "vmin": 0.001
+      }
+    ]
+  },
+  "name": "MABAT",
+  "resistor": {
+    "default_threshold_pct": 0.1,
+    "table_a": [
+      {
+        "extension_allowed_pct": 19.9,
+        "max_allowed_pct": 20.0,
+        "vmax": 0.05,
+        "vmin": 0.005
+      },
+      {
+        "extension_allowed_pct": 14.9,
+        "max_allowed_pct": 15.0,
+        "vmax": 3.99,
+        "vmin": 0.051
+      },
+      {
+        "extension_allowed_pct": 9.9,
+        "max_allowed_pct": 14.0,
+        "vmax": 9.99,
+        "vmin": 4.0
+      },
+      {
+        "extension_allowed_pct": 4.9,
+        "max_allowed_pct": 5.0,
+        "vmax": 99.9,
+        "vmin": 10.0
+      },
+      {
+        "extension_allowed_pct": 2.9,
+        "max_allowed_pct": 3.0,
+        "vmax": 1999.0,
+        "vmin": 100.0
+      },
+      {
+        "extension_allowed_pct": 0.9,
+        "max_allowed_pct": 1.0,
+        "vmax": 10000.0,
+        "vmin": 2000.0
+      }
+    ],
+    "table_b": [
+      {
+        "extension_allowed_pct": 24.0,
+        "max_allowed_pct": 25.0,
+        "vmax": 0.05,
+        "vmin": 0.005
+      },
+      {
+        "extension_allowed_pct": 19.0,
+        "max_allowed_pct": 20.0,
+        "vmax": 3.99,
+        "vmin": 0.051
+      },
+      {
+        "extension_allowed_pct": 14.0,
+        "max_allowed_pct": 15.0,
+        "vmax": 9.99,
+        "vmin": 4.0
+      },
+      {
+        "extension_allowed_pct": 9.0,
+        "max_allowed_pct": 10.0,
+        "vmax": 99.9,
+        "vmin": 10.0
+      },
+      {
+        "extension_allowed_pct": 4.0,
+        "max_allowed_pct": 5.0,
+        "vmax": 1999.0,
+        "vmin": 100.0
+      },
+      {
+        "extension_allowed_pct": 2.0,
+        "max_allowed_pct": 3.0,
+        "vmax": 10000.0,
+        "vmin": 2000.0
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Load profile sets from new `profiles/` JSON directory
- Save and register newly constructed profile sets into `profiles/`
- Populate profile dropdown dynamically from loaded profile sets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6b3b3731c832cb18f551659e5c3ad